### PR TITLE
Update NASA Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This list is based on the initial list compiled by [Alex Wallish](https://www.al
 |Mindbody|Not Cancelled|Interviews being cancelled|
 |MongoDB|Not Cancelled||
 |Mozilla|Not Cancelled|Remote Internship|
-|NASA|Not Cancelled||
+|NASA|Not Cancelled| Internship cancellation decision by April 15|
 |Nutanix|Not Cancelled|Worst case - Remote|
 |NVIDIA|Not Cancelled|Remote possible|
 |Okta|Not Cancelled|Toronto internships will be remote|


### PR DESCRIPTION
> The Agency is continuing to offer summer placements at its centers and facilities as it assesses the impact of the COVID-19 pandemic and how that impact will affect summer 2020 placements. You will be notified should this offer be withdrawn by your center internship office. NASA expects to make a determination by April 15.